### PR TITLE
Fix bug with project line percentages

### DIFF
--- a/src/views/components/Portfolio/components/LanguagesGraph.js
+++ b/src/views/components/Portfolio/components/LanguagesGraph.js
@@ -16,7 +16,7 @@ function LanguagesGraph(props) {
         }
     );
 
-    const [totalLines, setTotalLines] = useState(1)
+    const [totalLines, setTotalLines] = useState({"totalLineCount": 0})
 
     useEffect(() => {
         // debugger;

--- a/src/views/components/Portfolio/components/LanguagesGraph.js
+++ b/src/views/components/Portfolio/components/LanguagesGraph.js
@@ -51,7 +51,7 @@ function LanguagesGraph(props) {
                 <div className='languageList'>
                     {props.gitHubRepoLanguages ? props.gitHubRepoLanguages.map(language =>
                         <>
-                            <p style={{ color: colorObject[language[0]] }}>{language[0]}, {(language[1] / totalLines)}%</p>
+                            <p style={{ color: colorObject[language[0]] }}>{language[0]}, {(Math.round(100 * (language[1] / totalLines.totalLineCount)))}%</p>
                         </>
                     ) : null}
                 </div>


### PR DESCRIPTION
Previously, when computing the per-langugae breakdown of a project by language the LanguagesGraph component was inadvertently dividing the number of lines by an _object_ with a single property containing the total line count. This resulted in `NaN` being rendered as the percentage for each language.

This commit fixes the rendering logic to correctly reference the embedded field within the object. In addition, it adds basic rounding logic to convert the raw ratios to percentages, rounding in the process.

## Debugging

To debug the issue, I installed the React Developer Tools and searched the Components tab for the component in question. From there, I inspected the state and saw that one field was set to an object with one property: `{"totalLIneCount": ...}`. This provided the clue to the source of the `NaN` after rendering.

## Result

<img width="741" alt="Screenshot 2024-03-19 at 8 44 34 PM" src="https://github.com/erik-t-irgens/erik-irgens-website/assets/766944/1053289e-0cfc-4300-962e-01910bd94e6f">
